### PR TITLE
fix: exclude blur actors from lamp deformation

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -76,7 +76,18 @@ export default class CompizMagicLampEffectExtension extends Extension {
 
             this.destroyActorEffect(actor);
 
-            actor.add_effect_with_name(MINIMIZE_EFFECT_NAME, new MagicLampMinimizeEffect({settingsData: this.settingsData, icon: icon}));
+            const blurActor = actor.meta_window?.blur_actor ?? null;
+            const restoreBlurActor = blurActor?.visible ?? false;
+            if (blurActor) {
+                blurActor.hide();
+            }
+
+            actor.add_effect_with_name(MINIMIZE_EFFECT_NAME, new MagicLampMinimizeEffect({
+                settingsData: this.settingsData,
+                icon: icon,
+                blurActor,
+                restoreBlurActor,
+            }));
         });
 
         this.unminimizeId = global.window_manager.connect("unminimize", (e, actor) => {
@@ -91,7 +102,18 @@ export default class CompizMagicLampEffectExtension extends Extension {
 
             this.destroyActorEffect(actor);
 
-            actor.add_effect_with_name(UNMINIMIZE_EFFECT_NAME, new MagicLampUnminimizeEffect({settingsData: this.settingsData, icon: icon}));
+            const blurActor = actor.meta_window?.blur_actor ?? null;
+            const restoreBlurActor = blurActor?.visible ?? false;
+            if (blurActor) {
+                blurActor.hide();
+            }
+
+            actor.add_effect_with_name(UNMINIMIZE_EFFECT_NAME, new MagicLampUnminimizeEffect({
+                settingsData: this.settingsData,
+                icon: icon,
+                blurActor,
+                restoreBlurActor,
+            }));
         });
     }
 
@@ -190,6 +212,24 @@ class AbstractCommonMagicLampEffect extends Clutter.DeformEffect {
         super._init();
 
         this.settingsData = params.settingsData;
+        this.blurActor = params.blurActor ?? null;
+        this.restoreBlurActor = params.restoreBlurActor ?? false;
+        this.blurActorVisibleId = 0;
+
+        // Blur My Shell can add a monitor-sized background child to a window
+        // actor. Keep it out of the deformation texture for the complete
+        // animation, including visibility changes triggered by the compositor.
+        if (this.blurActor) {
+            this.blurActor.hide();
+            this.blurActorVisibleId = this.blurActor.connect(
+                'notify::visible',
+                (blurActor) => {
+                    if (blurActor.visible) {
+                        blurActor.hide();
+                    }
+                }
+            );
+        }
 
         this.EPSILON = 40;
 
@@ -333,12 +373,33 @@ class AbstractCommonMagicLampEffect extends Clutter.DeformEffect {
 
             this.destroy_actor(actor);
         }
+
+        if (this.blurActorVisibleId && this.blurActor?.get_parent()) {
+            this.blurActor.disconnect(this.blurActorVisibleId);
+        }
+        if (this.restoreBlurActor && this.blurActor?.get_parent()) {
+            this.blurActor.show();
+        }
+
+        this.blurActor = null;
+        this.restoreBlurActor = false;
+        this.blurActorVisibleId = 0;
     }
 
     vfunc_deform_vertex(w, h, v) {
         if (this.initialized) {
-            let propX = w / this.window.width;
-            let propY = h / this.window.height;
+            const rawPropX = w / this.window.width;
+            const rawPropY = h / this.window.height;
+
+            // A compositor effect may expand the paint texture far beyond the
+            // window actor. Those dimensions are not a window-coordinate scale
+            // and would send the genie tail to an unrelated screen position.
+            const expandedPaintVolume =
+                !Number.isFinite(rawPropX) || !Number.isFinite(rawPropY) ||
+                rawPropX < 0.8 || rawPropY < 0.8 ||
+                rawPropX > 1.25 || rawPropY > 1.25;
+            const propX = expandedPaintVolume ? 1 : rawPropX;
+            const propY = expandedPaintVolume ? 1 : rawPropY;
 
             if (this.iconPosition == St.Side.LEFT) {
                 this.width = this.window.width - this.icon.width + this.window.x * this.k;


### PR DESCRIPTION
## Summary

Prevent external application-blur actors from distorting the Magic Lamp deformation texture and sending the genie tail to an unrelated screen position.

## Problem

Blur My Shell's static application blur adds a monitor-sized background actor as a child of the window actor and clips it to the window frame. `Clutter.DeformEffect` therefore receives paint-texture dimensions close to the monitor size rather than the window size.

The existing code treats `texture size / window size` as a coordinate scale. With a monitor-sized blur child, that ratio can be several times larger than expected, causing windows to minimize off-screen or toward the wrong dock location.

Blur My Shell can also show its blur actor again when the window actor's visibility changes, so hiding it only once at effect construction is insufficient.

## Changes

- Temporarily hide a window's external `blur_actor` for the complete minimize/unminimize animation.
- Guard against the blur actor being shown again while the effect is active.
- Restore the blur actor's previous visibility after the animation completes.
- Reject paint-volume ratios far outside normal window/shadow bounds and deform those textures in window coordinates.
- Leave behavior unchanged for windows without an external blur actor.
- Use only runtime actor/monitor geometry; no resolution, scale factor, or dock coordinates are hard-coded.

## Testing

Tested on Fedora 44 with GNOME Shell 50.3 on Wayland and Blur My Shell 72 using static application blur.

- Verified minimize and restore animations across GTK, libadwaita, Electron, and XWayland applications.
- Verified the animation continues targeting the correct dock icon.
- Repeated rapid dock redisplay and multi-application launch cycles without new Shell/Clutter errors.
- Ran `node --check` on all JavaScript files.
- Ran `bash -n` on the packaging/install scripts.
- Ran `git diff --check` and strict schema compilation validation.

This is complementary to #15: that PR clamps the tail and handles stale icon geometry, while this change prevents an external monitor-sized paint actor from corrupting the deformation coordinate scale in the first place.
